### PR TITLE
Add options for multiple proto roots and to use wildcards on windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,9 @@
         <contributor>
             <name>abatalev</name>
         </contributor>
+	<contributor>
+            <name>tomforwood</name>
+        </contributor>
     </contributors>
 
     <scm>

--- a/src/main/java/com/google/protobuf/maven/AbstractProtocCompileMojo.java
+++ b/src/main/java/com/google/protobuf/maven/AbstractProtocCompileMojo.java
@@ -22,6 +22,14 @@ public abstract class AbstractProtocCompileMojo extends AbstractProtocMojo {
             defaultValue = "${basedir}/src/main/proto"
     )
     private File protoSourceRoot;
+	
+	/**
+     * The source directories containing the {@code .proto} definitions to be compiled.
+     */
+    @Parameter(
+            required = false
+    )
+    private File[] protoSourceRoots= {};
 
     /**
      * This is the directory into which the (optional) descriptor set file will be created.
@@ -45,9 +53,9 @@ public abstract class AbstractProtocCompileMojo extends AbstractProtocMojo {
     protected String descriptorSetClassifier;
 
     @Override
-    protected void doAttachProtoSources() {
-        projectHelper.addResource(project, getProtoSourceRoot().getAbsolutePath(),
-                ImmutableList.copyOf(getIncludes()), ImmutableList.copyOf(getExcludes()));
+    protected void doAttachProtoSources(File protoSourceRoot) {
+        	projectHelper.addResource(project, protoSourceRoot.getAbsolutePath(),
+                    ImmutableList.copyOf(getIncludes()), ImmutableList.copyOf(getExcludes()));
     }
 
     @Override
@@ -72,7 +80,10 @@ public abstract class AbstractProtocCompileMojo extends AbstractProtocMojo {
     }
 
     @Override
-    protected File getProtoSourceRoot() {
-        return protoSourceRoot;
+    protected File[] getProtoSourceRoots() {
+        if (protoSourceRoots==null || protoSourceRoots.length==0) {
+        	return new File[]{protoSourceRoot};
+        }
+    	return protoSourceRoots;
     }
 }

--- a/src/main/java/com/google/protobuf/maven/AbstractProtocTestCompileMojo.java
+++ b/src/main/java/com/google/protobuf/maven/AbstractProtocTestCompileMojo.java
@@ -1,6 +1,7 @@
 package com.google.protobuf.maven;
 
 import com.google.common.collect.ImmutableList;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -14,7 +15,7 @@ import java.util.List;
  */
 public abstract class AbstractProtocTestCompileMojo extends AbstractProtocMojo {
 
-    /**
+	/**
      * The source directories containing the test {@code .proto} definitions to be compiled.
      */
     @Parameter(
@@ -22,6 +23,14 @@ public abstract class AbstractProtocTestCompileMojo extends AbstractProtocMojo {
             defaultValue = "${basedir}/src/test/proto"
     )
     private File protoTestSourceRoot;
+	
+	/**
+     * The source directories containing the test {@code .proto} definitions to be compiled.
+     */
+    @Parameter(
+            required = false
+    )
+    private File[] protoTestSourceRoots;
 
     /**
      * This is the directory into which the (optional) descriptor set file will be created.
@@ -46,8 +55,8 @@ public abstract class AbstractProtocTestCompileMojo extends AbstractProtocMojo {
     protected String descriptorSetClassifier;
 
     @Override
-    protected void doAttachProtoSources() {
-        projectHelper.addTestResource(project, getProtoSourceRoot().getAbsolutePath(),
+    protected void doAttachProtoSources(File protoSourceRoot) {
+        projectHelper.addTestResource(project, protoSourceRoot.getAbsolutePath(),
                 ImmutableList.copyOf(getIncludes()), ImmutableList.copyOf(getExcludes()));
     }
 
@@ -73,7 +82,10 @@ public abstract class AbstractProtocTestCompileMojo extends AbstractProtocMojo {
     }
 
     @Override
-    protected File getProtoSourceRoot() {
-        return protoTestSourceRoot;
+    protected File[] getProtoSourceRoots() {
+        if (protoTestSourceRoots==null || protoTestSourceRoots.length==0) {
+        	return new File[]{protoTestSourceRoot};
+        }
+    	return protoTestSourceRoots;
     }
 }


### PR DESCRIPTION
Hi I contacted you a month or so to discuss this change. This allows you to specify a parameter to tell the plugin to use wildcards when generating windows command lines

We are using it as a solution to the bug with the command line becoming to long

It also allows a list of proto roots to be specified - our project has quite a few an disentagling them was tricky